### PR TITLE
Fix: Correctly convert item ID to string in cart controls

### DIFF
--- a/lib/presentation/widgets/cart/cart_item_quantity_controls.dart
+++ b/lib/presentation/widgets/cart/cart_item_quantity_controls.dart
@@ -26,7 +26,7 @@ class CartItemQuantityControls extends StatelessWidget {
             icon: Icon(Icons.add,
                 color: Theme.of(context).colorScheme.onPrimary, size: 18),
             onPressed: () {
-              context.read<CartCubit>().incrementItem(item.item.id as String);
+              context.read<CartCubit>().incrementItem(item.item.id.toString());
             },
             constraints: const BoxConstraints(
               minWidth: 32,
@@ -55,7 +55,7 @@ class CartItemQuantityControls extends StatelessWidget {
             icon: Icon(Icons.remove,
                 color: Theme.of(context).colorScheme.onSurface, size: 18),
             onPressed: () {
-              context.read<CartCubit>().decrementItem(item.item.id as String);
+              context.read<CartCubit>().decrementItem(item.item.id.toString());
             },
             constraints: const BoxConstraints(
               minWidth: 32,


### PR DESCRIPTION
A _TypeError was occurring when incrementing or decrementing the quantity of an item in the cart. This was caused by an incorrect cast of the `FoodItem.id` (an integer) to a String using `as String`.

This change replaces the incorrect cast with a call to `.toString()` to ensure the integer ID is properly converted to a string before being passed to the CartCubit.