### PR TITLE
feat: Implement mock review system with shared preferences

### DIFF
--- a/lib/data/datasources/mock/review_service_mock.dart
+++ b/lib/data/datasources/mock/review_service_mock.dart
@@ -1,0 +1,69 @@
+import 'dart:convert';
+import 'package:quick_bite/data/models/review.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:uuid/uuid.dart';
+
+class ReviewServiceMock {
+  final Map<int, List<Review>> _mockReviews = {
+    1: [
+      Review(
+        id: '1',
+        author: 'John Doe',
+        rating: 4.5,
+        review: 'Delicious! Best burger I have ever had.',
+        createdAt: DateTime.now().subtract(const Duration(days: 1)),
+      ),
+      Review(
+        id: '2',
+        author: 'Jane Smith',
+        rating: 5.0,
+        review: 'Absolutely amazing! Will definitely order again.',
+        createdAt: DateTime.now().subtract(const Duration(hours: 5)),
+      ),
+    ],
+    2: [
+      Review(
+        id: '3',
+        author: 'Peter Jones',
+        rating: 4.0,
+        review: 'Very good, but a bit too spicy for my taste.',
+        createdAt: DateTime.now().subtract(const Duration(days: 2)),
+      ),
+    ],
+  };
+
+  Future<List<Review>> getReviews(int foodItemId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final key = 'reviews_$foodItemId';
+    final reviewsJson = prefs.getString(key);
+
+    if (reviewsJson != null) {
+      final List<dynamic> decoded = json.decode(reviewsJson);
+      return decoded.map((json) => Review.fromJson(json)).toList();
+    } else {
+      return _mockReviews[foodItemId] ?? [];
+    }
+  }
+
+  Future<bool> addReview({
+    required int foodItemId,
+    required double rating,
+    required String review,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    final key = 'reviews_$foodItemId';
+    final reviews = await getReviews(foodItemId);
+
+    final newReview = Review(
+      id: const Uuid().v4(),
+      author: 'New User', // In a real app, you'd get the current user
+      rating: rating,
+      review: review,
+      createdAt: DateTime.now(),
+    );
+
+    reviews.add(newReview);
+    final reviewsJson = json.encode(reviews.map((r) => r.toJson()).toList());
+    return await prefs.setString(key, reviewsJson);
+  }
+}

--- a/lib/data/models/review.dart
+++ b/lib/data/models/review.dart
@@ -22,4 +22,30 @@ class Review {
       createdAt: DateTime.parse(json['createdAt'] as String),
     );
   }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'author': author,
+      'rating': rating,
+      'review': review,
+      'createdAt': createdAt.toIso8601String(),
+    };
+  }
+
+  Review copyWith({
+    String? id,
+    String? author,
+    double? rating,
+    String? review,
+    DateTime? createdAt,
+  }) {
+    return Review(
+      id: id ?? this.id,
+      author: author ?? this.author,
+      rating: rating ?? this.rating,
+      review: review ?? this.review,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
 }

--- a/lib/presentation/screens/food_details/food_item_details_screen.dart
+++ b/lib/presentation/screens/food_details/food_item_details_screen.dart
@@ -3,7 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_rating_bar/flutter_rating_bar.dart';
 import 'package:quick_bite/data/models/food_item.dart';
 import 'package:quick_bite/data/models/review.dart';
-import 'package:quick_bite/data/datasources/remote/review_service.dart';
+import 'package:quick_bite/data/datasources/mock/review_service_mock.dart';
 import 'package:quick_bite/presentation/view_models/cubit/cart_cubit.dart';
 import '../../../core/routs/routes.dart';
 import '../../../l10n/generated/app_localizations.dart';
@@ -27,7 +27,7 @@ class _FoodItemDetailsScreenState extends State<FoodItemDetailsScreen> {
   int _quantity = 1;
   final Set<String> _selectedCustomizations = {};
   late Future<List<Review>> _reviewsFuture;
-  final ReviewService _reviewService = ReviewService();
+  final ReviewServiceMock _reviewService = ReviewServiceMock();
 
   @override
   void initState() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   icons_launcher: ^3.0.1
   share_plus: ^7.2.0
   app_links: ^6.4.1
+  uuid: ^4.4.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Replaced the remote review service with a mock implementation.
- Mock reviews are now loaded from a local mock service.
- New reviews are saved to shared preferences.
- Updated the food details screen to use the new mock service.