### PR TITLE
feat: Remove demo credentials and improve login error handling

### DIFF
--- a/lib/data/repository/auth_repository_impl.dart
+++ b/lib/data/repository/auth_repository_impl.dart
@@ -104,17 +104,26 @@ class AuthRepositoryImpl implements AuthRepository {
       print('Error Message: ${dioError.message}');
 
       // Handle DioException errors by throwing custom server exceptions
+      final responseData = dioError.response?.data;
+      String errorMessage = 'An unknown error occurred';
+
+      if (responseData is Map<String, dynamic> && responseData.containsKey('message')) {
+        errorMessage = responseData['message'];
+      } else if (dioError.message != null) {
+        errorMessage = dioError.message!;
+      }
+
       switch (dioError.response?.statusCode) {
         case 400:
-          throw const BadRequestException('Invalid request format.');
+          throw BadRequestException(errorMessage);
         case 401:
-          throw const InvalidCredentialsException('Invalid email or password.');
+          throw InvalidCredentialsException(errorMessage);
         case 404:
-          throw const NotFoundException('Login service not found.');
+          throw NotFoundException('Login service not found.');
         case 500:
-          throw const InternalServerErrorException('An unexpected server error occurred.');
+          throw InternalServerErrorException('An unexpected server error occurred.');
         case null:
-          throw const NetworkException('Please check your internet connection.');
+          throw NetworkException('Please check your internet connection.');
         default:
           throw UnknownServerException('An unknown error occurred: ${dioError.message}');
       }

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -158,10 +158,6 @@
   "networkError": "خطأ في الشبكة. يرجى التحقق من اتصالك.",
   "serverError": "خطأ في الخادم. يرجى المحاولة لاحقاً.",
 
-  "demoCredentials": "بيانات تجريبية:",
-  "demoEmail": "البريد الإلكتروني: mohamed@gmail.com",
-  "demoPassword": "كلمة المرور: Fouad@2463187",
-
   "loadingDeliciousFood": "جاري تحميل الطعام اللذيذ...",
   "noItemsFound": "لم يتم العثور على عناصر",
   "tryDifferentCategory": "جرب اختيار فئة مختلفة",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -200,10 +200,6 @@
   "networkError": "Network error. Please check your connection.",
   "serverError": "Server error. Please try again later.",
 
-  "demoCredentials": "Demo Credentials:",
-  "demoEmail": "Email: mohamed@gmail.com",
-  "demoPassword": "Password: Fouad@2463187",
-
   "loadingDeliciousFood": "Loading delicious food...",
   "noItemsFound": "No items found",
   "tryDifferentCategory": "Try selecting a different category",

--- a/lib/presentation/screens/auth/login_screen.dart
+++ b/lib/presentation/screens/auth/login_screen.dart
@@ -298,37 +298,6 @@ class _LoginScreenState extends State<LoginScreen> {
                     ),
 
                     const SizedBox(height: 20),
-
-                    // Demo Credentials (for testing)
-                    Container(
-                      padding: const EdgeInsets.all(12),
-                      decoration: BoxDecoration(
-                        color: Colors.blue[50],
-                        borderRadius: BorderRadius.circular(8),
-                        border: Border.all(color: Colors.blue.shade200),
-                      ),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            l10n.demoCredentials,
-                            style: TextStyle(
-                              fontWeight: FontWeight.bold,
-                              color: Colors.blue[800],
-                            ),
-                          ),
-                          const SizedBox(height: 4),
-                          Text(
-                            l10n.demoEmail,
-                            style: TextStyle(color: Colors.blue[700]),
-                          ),
-                          Text(
-                            l10n.demoPassword,
-                            style: TextStyle(color: Colors.blue[700]),
-                          ),
-                        ],
-                      ),
-                    ),
                   ],
                 ),
               ),

--- a/lib/presentation/view_models/cubit/auth_cubit.dart
+++ b/lib/presentation/view_models/cubit/auth_cubit.dart
@@ -161,7 +161,7 @@ class AuthCubit extends Cubit<AuthState> {
       emit(state.copyWith(
         isAuthenticated: false,
         isLoading: false,
-        errorMessage: 'An unexpected error occurred. Please try again.',
+        errorMessage: e.toString(),
         userName: null,
         userEmail: null,
         userId: null,


### PR DESCRIPTION
- Removed the hardcoded demo credentials from the login screen UI.
- Removed the associated localization strings for the demo credentials.
- Updated the login error handling to extract and display specific error messages from the API response, instead of using generic, hardcoded messages.